### PR TITLE
Use latest busybox image, don't pin patch

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,5 @@
 # iron/go is the alpine image with only ca-certificates added
-FROM busybox:1.29.2-glibc
+FROM busybox:1.32-glibc
 WORKDIR /app
 # add static html files
 ADD static /app/static


### PR DESCRIPTION
* Upgrade the base image to the most recent version of BusyBox.
* Do not pin to the patch version of semver (https://semver.org/: *"PATCH version when you make backwards compatible bug fixes."*) so that subsequent rebuilds gain security fixes implicitly.